### PR TITLE
Updated and cleaned up PKGBUILD.

### DIFF
--- a/package/archlinux/PKGBUILD
+++ b/package/archlinux/PKGBUILD
@@ -2,15 +2,13 @@
 # Maintainer: Ivailo Monev <xakepa10@gmail.com>
 
 pkgname=katie-git
-pkgver=4.9.0.e49dfa18
+pkgver=4.9.0.rc17.r367.g28d8736c
 pkgrel=1
 pkgdesc='C++ toolkit derived from the Qt 4.8 framework'
 arch=('i486' 'i686' 'pentium4' 'x86_64' 'arm')
 url='https://github.com/fluxer/katie'
 license=('LGPL' 'FDL' 'custom')
-depends=('openssl' 'zlib' 'cups' 'libice' 'libsm' 'pcre' 'libxcursor' 'icu'
-        'libxext' 'libxfixes' 'libxinerama' 'libxrandr' 'libxrender' 'libx11'
-        'fontconfig' 'freetype2' 'libmng' 'zstd')
+depends=('libsm' 'libxcursor' 'libxinerama' 'libmng' 'icu' 'libcups' 'libxrandr' 'sqlite' 'fontconfig')
 makedepends=('cmake' 'git' 'postgresql' 'libmariadbclient' 'unixodbc' 'unifdef')
 optdepends=('postgresql-libs: PostgreSQL driver'
         'libmariadbclient: MariaDB driver'
@@ -22,7 +20,8 @@ conflicts=('katie')
 
 pkgver() {
     cd katie
-    printf "4.9.0.%s" "$(git rev-parse --short HEAD)"
+    #printf "4.9.0."r%s.%s "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+    git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
 prepare() {


### PR DESCRIPTION
Worked a little on katie PKGBUILD. First, I modified pkgver to get it in sync with tags.

pkgver=4.9.0.rc17.r367.g28d8736c is better, don't you think?

After a first build, namcap throw me this list of unneeded depends:

```
katie-git W: Dependency openssl included but already satisfied
katie-git W: Dependency zlib included but already satisfied
katie-git W: Dependency included and not needed ('cups')
katie-git W: Dependency libice included but already satisfied
katie-git W: Dependency pcre included but already satisfied
katie-git W: Dependency icu included but already satisfied
katie-git W: Dependency libxext included but already satisfied
katie-git W: Dependency libxfixes included but already satisfied
katie-git W: Dependency libxrender included but already satisfied
katie-git W: Dependency libx11 included but already satisfied
katie-git W: Dependency fontconfig included but already satisfied
katie-git W: Dependency freetype2 included but already satisfied
katie-git W: Dependency zstd included but already satisfied
```

I removed them, done another build and after a new namcap, I had to add into depends: icu, libxrander, fontconfig and libcups (instead of cups).

I will look at every other PKGBUILDs in katana repository to update and clean them up.